### PR TITLE
Glow around page title

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -236,6 +236,7 @@ export default function App({
           <h1 className="text-5xl text-black p-4 "
             style={{
               fontFamily: 'Typewriter',
+              textShadow: '0px 0 2px #fff, 0px 0px 15px #b9402f',
             }}
           >
             Advent of Distributed Systems


### PR DESCRIPTION
This should add a glow around the page title so the black text doesn't blend into the background image.

Before/after:

> <img width="1698" alt="image" src="https://github.com/cryingpotat0/adventofdistributedsystems/assets/19393950/fba58c12-52aa-4165-bc9d-98d5e380c9ad">
